### PR TITLE
fix: change SameSite cookie attribute to 'None' for accessToken and r…

### DIFF
--- a/src/api/authentication/handler.js
+++ b/src/api/authentication/handler.js
@@ -93,14 +93,14 @@ class AuthenticationHandler {
         .state("accessToken", accessToken.token, {
           isHttpOnly: true,
           isSecure: true,
-          sameSite: "Strict",
+          sameSite: "None",
           path: "/",
           ttl: 60 * 60 * 1000, // 15 mins
         })
         .state("refreshToken", refreshToken.token, {
           isHttpOnly: true,
           isSecure: true,
-          sameSite: "Strict",
+          sameSite: "None",
           path: "/",
           ttl: 7 * 24 * 60 * 60 * 1000, // 7 days
         });


### PR DESCRIPTION
…efreshToken to support cross-origin requests