### PR TITLE
refactor(db): standardise naming conventions for routines and views

### DIFF
--- a/migrations/1747878254170_create-user-audit-log.js
+++ b/migrations/1747878254170_create-user-audit-log.js
@@ -9,76 +9,78 @@ exports.shorthands = undefined;
  * @returns {Promise<void> | void}
  */
 exports.up = (pgm) => {
-    // 1. Create audit log table
-    pgm.createTable('user_audit_log', {
-         id: {
-            type: "UUID",
-            primaryKey: true,
-            default: pgm.func("gen_random_uuid()"),
-        },
-        user_id: { type: 'uuid', notNull: true },
-        action: { type: 'varchar(10)', notNull: true },
-        old_data: { type: 'jsonb' },
-        new_data: { type: 'jsonb' },
-        changed_by: { type: 'uuid' },
-        changed_at: {
-            type: 'timestamp',
-            notNull: true,
-            default: pgm.func('current_timestamp'),
-        },
-    });
+  // 1. Create audit log table
+  pgm.createTable('log_user_audit', {
+    id: {
+      type: "UUID",
+      primaryKey: true,
+      default: pgm.func("gen_random_uuid()"),
+    },
+    user_id: { type: 'uuid', notNull: true },
+    action: { type: 'varchar(10)', notNull: true },
+    old_data: { type: 'jsonb' },
+    new_data: { type: 'jsonb' },
+    changed_by: { type: 'uuid' },
+    changed_at: {
+      type: 'timestamp',
+      notNull: true,
+      default: pgm.func('current_timestamp'),
+    },
+  });
 
-    // 2. Add constraint: action must be one of CREATE, UPDATE, DELETE
-    pgm.addConstraint('user_audit_log', 'user_audit_log_action_check', {
-        check: "action IN ('CREATE', 'UPDATE', 'DELETE')",
-    });
+  // 2. Add constraint: action must be one of CREATE, UPDATE, DELETE
+  pgm.sql(`
+        ALTER TABLE log_user_audit
+        ADD CONSTRAINT log_user_audit_action_check
+        CHECK (action IN ('CREATE', 'UPDATE', 'DELETE'));
+    `);
 
-    // 3. Create trigger function
-    pgm.sql(`
-    CREATE OR REPLACE FUNCTION log_user_changes()
-    RETURNS TRIGGER AS $$
-    DECLARE
-      v_action VARCHAR(10);
-      v_user_id UUID;
-    BEGIN
-      IF (TG_OP = 'DELETE') THEN
-        v_action := 'DELETE';
-        v_user_id := OLD.id;
-      ELSIF (TG_OP = 'UPDATE') THEN
-        v_action := 'UPDATE';
-        v_user_id := NEW.id;
-      ELSIF (TG_OP = 'INSERT') THEN
-        v_action := 'CREATE';
-        v_user_id := NEW.id;
-      END IF;
+  // 3. Create trigger function
+  pgm.sql(`
+        CREATE OR REPLACE FUNCTION fn_log_user_changes()
+        RETURNS TRIGGER AS $$
+        DECLARE
+            v_action VARCHAR(10);
+            v_user_id UUID;
+        BEGIN
+            IF (TG_OP = 'DELETE') THEN
+                v_action := 'DELETE';
+                v_user_id := OLD.id;
+            ELSIF (TG_OP = 'UPDATE') THEN
+                v_action := 'UPDATE';
+                v_user_id := NEW.id;
+            ELSIF (TG_OP = 'INSERT') THEN
+                v_action := 'CREATE';
+                v_user_id := NEW.id;
+            END IF;
 
-      INSERT INTO user_audit_log (
-        user_id, action, old_data, new_data, changed_by, changed_at
-      ) VALUES (
-        v_user_id,
-        v_action,
-        CASE WHEN TG_OP IN ('UPDATE','DELETE') THEN to_jsonb(OLD) ELSE NULL END,
-        CASE WHEN TG_OP IN ('INSERT','UPDATE') THEN to_jsonb(NEW) ELSE NULL END,
-        CASE 
-          WHEN TG_OP = 'DELETE' THEN OLD.deleted_by
-          WHEN TG_OP = 'UPDATE' THEN NEW.updated_by
-          WHEN TG_OP = 'INSERT' THEN NEW.created_by
-        END,
-        current_timestamp
-      );
+            INSERT INTO log_user_audit (
+                user_id, action, old_data, new_data, changed_by, changed_at
+            ) VALUES (
+                v_user_id,
+                v_action,
+                CASE WHEN TG_OP IN ('UPDATE','DELETE') THEN to_jsonb(OLD) ELSE NULL END,
+                CASE WHEN TG_OP IN ('INSERT','UPDATE') THEN to_jsonb(NEW) ELSE NULL END,
+                CASE 
+                    WHEN TG_OP = 'DELETE' THEN OLD.deleted_by
+                    WHEN TG_OP = 'UPDATE' THEN NEW.updated_by
+                    WHEN TG_OP = 'INSERT' THEN NEW.created_by
+                END,
+                current_timestamp
+            );
 
-      RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
-    END;
-    $$ LANGUAGE plpgsql;
-  `);
+            RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+        END;
+        $$ LANGUAGE plpgsql;
+    `);
 
-    // 4. Attach trigger to `user` table
-    pgm.createTrigger('user', 'user_audit_trigger', {
-        when: 'AFTER',
-        operation: ['INSERT', 'UPDATE', 'DELETE'],
-        level: 'ROW',
-        function: 'log_user_changes',
-    });
+  // 4. Attach trigger to `user` table
+  pgm.sql(`
+        CREATE TRIGGER trg_user_audit
+        AFTER INSERT OR UPDATE OR DELETE ON "user"
+        FOR EACH ROW
+        EXECUTE FUNCTION fn_log_user_changes();
+    `);
 };
 
 /**
@@ -87,10 +89,10 @@ exports.up = (pgm) => {
  * @returns {Promise<void> | void}
  */
 exports.down = (pgm) => {
-    // Drop trigger and function first (order matters)
-    pgm.dropTrigger('user', 'user_audit_trigger');
-    pgm.sql(`DROP FUNCTION IF EXISTS log_user_changes();`);
+  // Drop trigger and function first (order matters)
+  pgm.sql(`DROP TRIGGER IF EXISTS trg_user_audit ON "user"`);
+  pgm.sql(`DROP FUNCTION IF EXISTS fn_log_user_changes()`);
 
-    // Drop table
-    pgm.dropTable('user_audit_log');
+  // Drop table
+  pgm.dropTable('log_user_audit');
 };

--- a/migrations/1747912525013_create-rekap-janji-temu-function.js
+++ b/migrations/1747912525013_create-rekap-janji-temu-function.js
@@ -10,7 +10,7 @@ exports.shorthands = undefined;
  */
 exports.up = (pgm) => {
     pgm.sql(`
-        CREATE OR REPLACE FUNCTION rekap_janji_temu()
+        CREATE OR REPLACE FUNCTION fn_rekap_janji_temu()
             RETURNS TABLE (
             total BIGINT,
             total_dikonfirmasi BIGINT,
@@ -37,6 +37,6 @@ exports.up = (pgm) => {
  */
 exports.down = (pgm) => {
     pgm.sql(`
-        DROP FUNCTION IF EXISTS rekap_janji_temu;
+        DROP FUNCTION IF EXISTS fn_rekap_janji_temu;
     `);
 };

--- a/migrations/1747912611455_create-rekap-janji-temu-per-konselor-function.js
+++ b/migrations/1747912611455_create-rekap-janji-temu-per-konselor-function.js
@@ -10,7 +10,7 @@ exports.shorthands = undefined;
  */
 exports.up = (pgm) => {
     pgm.sql(`
-        CREATE OR REPLACE FUNCTION rekap_janji_temu_per_konselor()
+        CREATE OR REPLACE FUNCTION fn_rekap_janji_temu_per_konselor()
         RETURNS TABLE (
         konselor_id UUID,
         nama_konselor TEXT,
@@ -38,6 +38,6 @@ exports.up = (pgm) => {
  */
 exports.down = (pgm) => {
     pgm.sql(`
-        DROP FUNCTION IF EXISTS rekap_janji_temu_per_konselor;
+        DROP FUNCTION IF EXISTS fn_rekap_janji_temu_per_konselor;
     `);
  };

--- a/migrations/1747912991264_create-rekap-janji-temu-harian-function-trigger.js
+++ b/migrations/1747912991264_create-rekap-janji-temu-harian-function-trigger.js
@@ -10,25 +10,25 @@ exports.shorthands = undefined;
  */
 exports.up = (pgm) => {
     pgm.sql(`
-        CREATE OR REPLACE FUNCTION rekap_harian_trigger()
+        CREATE OR REPLACE FUNCTION fn_rekap_janji_temu_harian()
         RETURNS TRIGGER AS $$
         BEGIN
-        INSERT INTO log_rekap_janji_temu_harian(tanggal, total, dikonfirmasi, ditolak, menunggu_konfirmasi)
-        SELECT 
-            CURRENT_DATE,
-            COUNT(*) FILTER (WHERE deleted_at IS NULL),
-            COUNT(*) FILTER (WHERE status = 'dikonfirmasi' AND deleted_at IS NULL),
-            COUNT(*) FILTER (WHERE status = 'ditolak' AND deleted_at IS NULL),
-            COUNT(*) FILTER (WHERE status = 'menunggu_konfirmasi' AND deleted_at IS NULL)
-        FROM janji_temu
-        ON CONFLICT (tanggal)
-        DO UPDATE SET
-            total = EXCLUDED.total,
-            dikonfirmasi = EXCLUDED.dikonfirmasi,
-            ditolak = EXCLUDED.ditolak,
-            menunggu_konfirmasi = EXCLUDED.menunggu_konfirmasi;
+            INSERT INTO log_rekap_janji_temu_harian(tanggal, total, dikonfirmasi, ditolak, menunggu_konfirmasi)
+            SELECT
+                CURRENT_DATE,
+                COUNT(*) FILTER (WHERE deleted_at IS NULL),
+                COUNT(*) FILTER (WHERE status = 'dikonfirmasi' AND deleted_at IS NULL),
+                COUNT(*) FILTER (WHERE status = 'ditolak' AND deleted_at IS NULL),
+                COUNT(*) FILTER (WHERE status = 'menunggu_konfirmasi' AND deleted_at IS NULL)
+            FROM janji_temu
+            ON CONFLICT (tanggal)
+            DO UPDATE SET
+                total = EXCLUDED.total,
+                dikonfirmasi = EXCLUDED.dikonfirmasi,
+                ditolak = EXCLUDED.ditolak,
+                menunggu_konfirmasi = EXCLUDED.menunggu_konfirmasi;
 
-        RETURN NULL;
+            RETURN NEW;
         END;
         $$ LANGUAGE plpgsql;
     `);
@@ -41,6 +41,6 @@ exports.up = (pgm) => {
  */
 exports.down = (pgm) => {
     pgm.sql(`
-        DROP FUNCTION IF EXISTS rekap_harian_trigger;
+        DROP FUNCTION IF EXISTS fn_rekap_janji_temu_harian;
     `);
 };

--- a/migrations/1747913009342_create-rekap-janji-temu-harian-trigger.js
+++ b/migrations/1747913009342_create-rekap-janji-temu-harian-trigger.js
@@ -10,10 +10,10 @@ exports.shorthands = undefined;
  */
 exports.up = (pgm) => {
     pgm.sql(`
-        CREATE TRIGGER trg_rekap_harian
+        CREATE TRIGGER trg_rekap_janji_temu_harian
         AFTER INSERT ON janji_temu
         FOR EACH STATEMENT
-        EXECUTE FUNCTION rekap_harian_trigger();
+        EXECUTE FUNCTION fn_rekap_janji_temu_harian();
     `);
 };
 
@@ -24,6 +24,6 @@ exports.up = (pgm) => {
  */
 exports.down = (pgm) => {
     pgm.sql(`
-        DROP TRIGGER IF EXISTS trg_rekap_harian ON janji_temu;
+        DROP TRIGGER IF EXISTS trg_rekap_janji_temu_harian ON janji_temu;
     `);
 };

--- a/migrations/1747913469482_create-validasi-pengajuan-duplikat-trigger.js
+++ b/migrations/1747913469482_create-validasi-pengajuan-duplikat-trigger.js
@@ -10,7 +10,7 @@ exports.shorthands = undefined;
  */
 exports.up = (pgm) => {
     pgm.sql(`
-        CREATE OR REPLACE FUNCTION validasi_pengajuan_duplikat()
+        CREATE OR REPLACE FUNCTION fn_validasi_pengajuan_duplikat()
         RETURNS TRIGGER AS $$
         BEGIN
         IF EXISTS (
@@ -32,7 +32,7 @@ exports.up = (pgm) => {
         CREATE TRIGGER trg_validasi_pengajuan_duplikat
         BEFORE INSERT ON janji_temu
         FOR EACH ROW
-        EXECUTE FUNCTION validasi_pengajuan_duplikat();
+        EXECUTE FUNCTION fn_validasi_pengajuan_duplikat();
     `);
 };
 
@@ -47,6 +47,6 @@ exports.down = (pgm) => {
     `);
 
      pgm.sql(`
-        DROP FUNCTION IF EXISTS validasi_pengajuan_duplikat;
+        DROP FUNCTION IF EXISTS fn_validasi_pengajuan_duplikat;
     `);
 };

--- a/migrations/1747913911411_create-perubahan-status-janji-temu-trigger.js
+++ b/migrations/1747913911411_create-perubahan-status-janji-temu-trigger.js
@@ -10,7 +10,7 @@ exports.shorthands = undefined;
  */
 exports.up = (pgm) => {
     pgm.sql(`
-        CREATE OR REPLACE FUNCTION catat_perubahan_status_janji_temu()
+        CREATE OR REPLACE FUNCTION fn_log_status_janji_temu()
         RETURNS TRIGGER AS $$
         BEGIN
         INSERT INTO log_status_janji_temu (
@@ -34,11 +34,11 @@ exports.up = (pgm) => {
     `);
 
     pgm.sql(`
-        CREATE TRIGGER trg_catat_perubahan_status_janji_temu
+        CREATE TRIGGER trg_log_status_janji_temu
         AFTER UPDATE ON janji_temu
         FOR EACH ROW
         WHEN (OLD.status IS DISTINCT FROM NEW.status)
-        EXECUTE FUNCTION catat_perubahan_status_janji_temu();
+        EXECUTE FUNCTION fn_log_status_janji_temu();
     `);
 };
 
@@ -50,11 +50,11 @@ exports.up = (pgm) => {
 exports.down = (pgm) => {
     // First drop the trigger that depends on the function
     pgm.sql(`
-        DROP TRIGGER IF EXISTS trg_catat_perubahan_status_janji_temu ON janji_temu;
+        DROP TRIGGER IF EXISTS trg_log_status_janji_temu ON janji_temu;
     `);
 
     // Then drop the function safely
     pgm.sql(`
-        DROP FUNCTION IF EXISTS catat_perubahan_status_janji_temu;
+        DROP FUNCTION IF EXISTS fn_log_status_janji_temu();
     `);
 };

--- a/migrations/1747914663299_create-total-mahasisiwa-janji-temu-function-views.js
+++ b/migrations/1747914663299_create-total-mahasisiwa-janji-temu-function-views.js
@@ -11,7 +11,7 @@ exports.shorthands = undefined;
 exports.up = (pgm) => {
     // Function: Hitung total mahasiswa dalam rentang tanggal
     pgm.sql(`
-        CREATE OR REPLACE FUNCTION hitung_totsl_mahasiswa_janji_temu_dalam_rentang(
+        CREATE OR REPLACE FUNCTION fn_hitung_total_mahasiswa_janji_temu_dalam_rentang(
         tanggal_mulai DATE,
         tanggal_selesai DATE
         )
@@ -30,7 +30,7 @@ exports.up = (pgm) => {
 
     // Function: Hitung total mahasiswa per konselor
     pgm.sql(`
-            CREATE OR REPLACE FUNCTION hitung_totsl_mahasiswa_janji_temu_per_konselor(
+            CREATE OR REPLACE FUNCTION fn_hitung_total_mahasiswa_janji_temu_per_konselor(
             konselor_id UUID
             )
             RETURNS INTEGER AS $$
@@ -47,7 +47,7 @@ exports.up = (pgm) => {
 
     // Function: Hitung total mahasiswa per status
     pgm.sql(`
-        CREATE OR REPLACE FUNCTION hitung_totsl_mahasiswa_janji_temu_per_status(
+        CREATE OR REPLACE FUNCTION fn_hitung_total_mahasiswa_janji_temu_per_status(
         status_input status_janji_temu
         )
         RETURNS INTEGER AS $$
@@ -64,7 +64,7 @@ exports.up = (pgm) => {
 
     // Function: Hitung total mahasiswa per tipe konsultasi
     pgm.sql(`
-        CREATE OR REPLACE FUNCTION hitung_totsl_mahasiswa_janji_temu_per_tipe(
+        CREATE OR REPLACE FUNCTION fn_hitung_total_mahasiswa_janji_temu_per_tipe(
         tipe tipe_konsultasi
         )
         RETURNS INTEGER AS $$
@@ -81,7 +81,7 @@ exports.up = (pgm) => {
 
     // View: Ringkasan total mahasiswa per bulan
     pgm.sql(`
-        CREATE OR REPLACE VIEW view_total_mahasiswa_janji_temu_per_bulan AS
+        CREATE OR REPLACE VIEW vw_total_mahasiswa_janji_temu_per_bulan AS
         SELECT
         DATE_TRUNC('month', tanggal_pengajuan) AS bulan,
         COUNT(DISTINCT nrp) AS total_mahasiswa
@@ -93,7 +93,7 @@ exports.up = (pgm) => {
 
     // View: Ringkasan total mahasiswa per tahun
     pgm.sql(`
-        CREATE OR REPLACE VIEW view_total_mahasiswa_janji_temu_per_tahun AS
+        CREATE OR REPLACE VIEW vw_total_mahasiswa_janji_temu_per_tahun AS
         SELECT
         DATE_TRUNC('year', tanggal_pengajuan) AS tahun,
         COUNT(DISTINCT nrp) AS total_mahasiswa
@@ -105,7 +105,7 @@ exports.up = (pgm) => {
 
     // View: Ringkasan total mahasiswa per tipe konsultasi
     pgm.sql(`
-        CREATE OR REPLACE VIEW view_total_mahasiswa_janji_temu_per_tipe_konsultasi AS
+        CREATE OR REPLACE VIEW vw_total_mahasiswa_janji_temu_per_tipe_konsultasi AS
         SELECT
         tipe_konsultasi,
         COUNT(DISTINCT nrp) AS total_mahasiswa
@@ -116,7 +116,7 @@ exports.up = (pgm) => {
 
     // View: Ringkasan total mahasiswa per status
     pgm.sql(`
-        CREATE OR REPLACE VIEW view_total_mahasiswa_janji_temu_per_status AS
+        CREATE OR REPLACE VIEW vw_total_mahasiswa_janji_temu_per_status AS
         SELECT
         status,
         COUNT(DISTINCT nrp) AS total_mahasiswa
@@ -134,17 +134,17 @@ exports.up = (pgm) => {
 exports.down = (pgm) => {
     pgm.sql(`
         DROP FUNCTION IF EXISTS
-        hitung_totsl_mahasiswa_janji_temu_dalam_rentang,
-        hitung_totsl_mahasiswa_janji_temu_per_konselor,
-        hitung_totsl_mahasiswa_janji_temu_per_status,
-        hitung_totsl_mahasiswa_janji_temu_per_tipe;
+        fn_hitung_total_mahasiswa_janji_temu_dalam_rentang,
+        fn_hitung_total_mahasiswa_janji_temu_per_konselor,
+        fn_hitung_total_mahasiswa_janji_temu_per_status,
+        fn_hitung_total_mahasiswa_janji_temu_per_tipe;
     `);
 
     pgm.sql(`
         DROP VIEW IF EXISTS
-        view_total_mahasiswa_janji_temu_per_bulan,
-        view_total_mahasiswa_janji_temu_per_tahun,
-        view_total_mahasiswa_janji_temu_per_tipe_konsultasi,
-        view_total_mahasiswa_janji_temu_per_status;
+        vw_total_mahasiswa_janji_temu_per_bulan,
+        vw_total_mahasiswa_janji_temu_per_tahun,
+        vw_total_mahasiswa_janji_temu_per_tipe_konsultasi,
+        vw_total_mahasiswa_janji_temu_per_status;
     `);
 };

--- a/migrations/1747991838513_create-get-jadwal-konseling-konselor-function.js
+++ b/migrations/1747991838513_create-get-jadwal-konseling-konselor-function.js
@@ -8,7 +8,7 @@ exports.shorthands = undefined;
  */
 exports.up = (pgm) => {
     pgm.sql(`
-        CREATE OR REPLACE FUNCTION get_jadwal_konseling_konselor(p_konselor_id UUID)
+        CREATE OR REPLACE FUNCTION fn_get_jadwal_konseling_konselor(p_konselor_id UUID)
         RETURNS TABLE (
         konseling_id UUID,
         tanggal_konseling DATE,
@@ -46,6 +46,6 @@ exports.up = (pgm) => {
  */
 exports.down = (pgm) => {
     pgm.sql(`
-        DROP FUNCTION IF EXISTS get_jadwal_konseling_konselor;
+        DROP FUNCTION IF EXISTS fn_get_jadwal_konseling_konselor;
     `);
 };

--- a/migrations/1747992005115_create-prevent-konselor-overlap-function-trigger.js
+++ b/migrations/1747992005115_create-prevent-konselor-overlap-function-trigger.js
@@ -8,7 +8,7 @@ exports.shorthands = undefined;
  */
 exports.up = (pgm) => {
     pgm.sql(`
-        CREATE OR REPLACE FUNCTION prevent_konselor_overlap()
+        CREATE OR REPLACE FUNCTION fn_prevent_konselor_overlap()
         RETURNS trigger AS $$
         BEGIN
         IF EXISTS (
@@ -26,10 +26,10 @@ exports.up = (pgm) => {
         END;
         $$ LANGUAGE plpgsql;
 
-        CREATE TRIGGER prevent_konselor_overlap
+        CREATE TRIGGER trg_prevent_konselor_overlap
         BEFORE INSERT OR UPDATE ON konseling
         FOR EACH ROW
-        EXECUTE FUNCTION prevent_konselor_overlap();
+        EXECUTE FUNCTION fn_prevent_konselor_overlap();
   `);
 };
 
@@ -38,7 +38,7 @@ exports.up = (pgm) => {
  */
 exports.down = (pgm) => {
     pgm.sql(`
-        DROP TRIGGER IF EXISTS prevent_konselor_overlap ON konseling;
-        DROP FUNCTION IF EXISTS prevent_konselor_overlap;
+        DROP TRIGGER IF EXISTS trg_prevent_konselor_overlap ON konseling;
+        DROP FUNCTION IF EXISTS fn_prevent_konselor_overlap;
     `);
 };

--- a/migrations/1747992174158_create-total-konseling-per-konselor-views.js
+++ b/migrations/1747992174158_create-total-konseling-per-konselor-views.js
@@ -8,7 +8,7 @@ exports.shorthands = undefined;
  */
 exports.up = (pgm) => {
     pgm.sql(`
-        CREATE OR REPLACE VIEW v_total_sesi_konseling_per_konselor AS
+        CREATE OR REPLACE VIEW vw_total_sesi_konseling_per_konselor AS
         SELECT
         kp.id AS konselor_id,
         kp.nama_lengkap AS nama_konselor,
@@ -25,6 +25,6 @@ exports.up = (pgm) => {
  */
 exports.down = (pgm) => {
     pgm.sql(`
-        DROP VIEW IF EXISTS v_total_konseling_per_konselor;
+        DROP VIEW IF EXISTS vw_total_sesi_konseling_per_konselor;
     `);
 };

--- a/migrations/1747992247429_create-statistik-kehadiran-permahasiswa-views.js
+++ b/migrations/1747992247429_create-statistik-kehadiran-permahasiswa-views.js
@@ -8,7 +8,7 @@ exports.shorthands = undefined;
  */
 exports.up = (pgm) => {
     pgm.sql(`
-        CREATE OR REPLACE VIEW v_statistik_kehadiran_per_mahasiswa AS
+        CREATE OR REPLACE VIEW vw_statistik_kehadiran_per_mahasiswa AS
         SELECT
         m.id AS mahasiswa_id,
         m.nama_lengkap AS nama_mahasiswa,
@@ -32,6 +32,6 @@ exports.up = (pgm) => {
  */
 exports.down = (pgm) => {
     pgm.sql(`
-        DROP VIEW IF EXISTS v_statistik_kehadiran_per_mahasiswa;
+        DROP VIEW IF EXISTS vw_statistik_kehadiran_per_mahasiswa;
     `);
 };

--- a/migrations/1747992598313_create-jumlah-sesi-konselor-pertanggal-views.js
+++ b/migrations/1747992598313_create-jumlah-sesi-konselor-pertanggal-views.js
@@ -8,7 +8,7 @@ exports.shorthands = undefined;
  */
 exports.up = (pgm) => {
     pgm.sql(`
-        CREATE OR REPLACE VIEW v_jumlah_sesi_per_tanggal_per_konselor AS
+        CREATE OR REPLACE VIEW vw_jumlah_sesi_per_tanggal_per_konselor AS
         SELECT
         kp.id AS konselor_id,
         kp.nama_lengkap AS nama_konselor,
@@ -27,6 +27,6 @@ exports.up = (pgm) => {
  */
 exports.down = (pgm) => {
     pgm.sql(`
-        DROP VIEW IF EXISTS v_jumlah_sesi_per_tanggal_per_konselor;
+        DROP VIEW IF EXISTS vw_jumlah_sesi_per_tanggal_per_konselor;
     `);
 };

--- a/migrations/1747995834763_create-otomatis-update-status-berlangsung-function.js
+++ b/migrations/1747995834763_create-otomatis-update-status-berlangsung-function.js
@@ -8,7 +8,7 @@ exports.shorthands = undefined;
  */
 exports.up = (pgm) => {
     pgm.sql(`
-        CREATE OR REPLACE FUNCTION update_status_berlangsung_otomatis()
+        CREATE OR REPLACE FUNCTION fn_update_status_berlangsung_otomatis()
         RETURNS void AS $$
         BEGIN
         UPDATE konseling
@@ -32,6 +32,6 @@ exports.up = (pgm) => {
  */
 exports.down = (pgm) => {
     pgm.sql(`
-        DROP FUNCTION IF EXISTS update_status_berlangsung_otomatis;
+        DROP FUNCTION IF EXISTS fn_update_status_berlangsung_otomatis;
     `);
 };

--- a/migrations/1747996373613_create-total-sesi-konseling-selesai-mahasiswa-views.js
+++ b/migrations/1747996373613_create-total-sesi-konseling-selesai-mahasiswa-views.js
@@ -10,7 +10,7 @@ exports.shorthands = undefined;
  */
 exports.up = (pgm) => {
     pgm.sql(`
-        CREATE OR REPLACE VIEW v_total_sesi_selesai_per_mahasiswa AS
+        CREATE OR REPLACE VIEW vw_total_sesi_selesai_per_mahasiswa AS
         SELECT
         m.id AS mahasiswa_id,
         m.nama_lengkap AS nama_mahasiswa,
@@ -32,5 +32,5 @@ exports.up = (pgm) => {
  * @returns {Promise<void> | void}
  */
 exports.down = (pgm) => {
-    pgm.sql(`DROP VIEW IF EXISTS v_total_sesi_selesai_per_mahasiswa;`);
+    pgm.sql(`DROP VIEW IF EXISTS vw_total_sesi_selesai_per_mahasiswa;`);
 };

--- a/migrations/1748309242584_create-tolak-verifikasi-mahasiswa-dan-janji-temu-procedure.js
+++ b/migrations/1748309242584_create-tolak-verifikasi-mahasiswa-dan-janji-temu-procedure.js
@@ -10,7 +10,7 @@ exports.shorthands = undefined;
  */
 exports.up = (pgm) => {
     pgm.sql(`
-        CREATE OR REPLACE PROCEDURE tolak_verifikasi_mahasiswa_dan_janji_temu(
+        CREATE OR REPLACE PROCEDURE prc_tolak_verifikasi_mahasiswa_dan_janji_temu(
             p_mahasiswa_id UUID,
             p_catatan_verifikasi TEXT,
             p_verified_at TIMESTAMP,
@@ -88,7 +88,7 @@ exports.up = (pgm) => {
  */
 exports.down = (pgm) => {
     pgm.sql(`
-        DROP PROCEDURE IF EXISTS tolak_verifikasi_mahasiswa_dan_janji_temu(
+        DROP PROCEDURE IF EXISTS prc_tolak_verifikasi_mahasiswa_dan_janji_temu(
             UUID, TEXT, TIMESTAMP, UUID, TEXT, UUID, UUID
         );
     `);

--- a/migrations/1748797886160_create-total-mahasiswa-view.js
+++ b/migrations/1748797886160_create-total-mahasiswa-view.js
@@ -10,7 +10,7 @@ exports.shorthands = undefined;
  */
 exports.up = (pgm) => {
     pgm.sql(`
-        CREATE OR REPLACE VIEW view_total_mahasiswa AS
+        CREATE OR REPLACE VIEW vw_total_mahasiswa AS
         SELECT COUNT(*)::integer AS total_mahasiswa
         FROM mahasiswa
         WHERE is_active = TRUE AND deleted_at IS NULL;
@@ -23,5 +23,5 @@ exports.up = (pgm) => {
  * @returns {Promise<void> | void}
  */
 exports.down = (pgm) => {
-    pgm.sql('DROP VIEW IF EXISTS view_total_mahasiswa;');
+    pgm.sql('DROP VIEW IF EXISTS vw_total_mahasiswa;');
  };

--- a/migrations/1748798012972_create-demografi-mahasiswa-per-prodi-view.js
+++ b/migrations/1748798012972_create-demografi-mahasiswa-per-prodi-view.js
@@ -10,7 +10,7 @@ exports.shorthands = undefined;
  */
 exports.up = (pgm) => {
     pgm.sql(`
-    CREATE VIEW view_demografi_mahasiswa_per_prodi AS
+    CREATE VIEW vw_demografi_mahasiswa_per_prodi AS
     SELECT 
         d.name AS departemen,
         ps.jenjang,
@@ -31,5 +31,5 @@ exports.up = (pgm) => {
  * @returns {Promise<void> | void}
  */
 exports.down = (pgm) => {
-    pgm.sql('DROP VIEW IF EXISTS view_demografi_mahasiswa_per_prodi;');
+    pgm.sql('DROP VIEW IF EXISTS vw_demografi_mahasiswa_per_prodi;');
 };

--- a/migrations/1748798446128_create-total-konseling-per-bulan-view.js
+++ b/migrations/1748798446128_create-total-konseling-per-bulan-view.js
@@ -10,7 +10,7 @@ exports.shorthands = undefined;
  */
 exports.up = (pgm) => {
      pgm.sql(`
-         CREATE OR REPLACE VIEW view_total_konseling_per_bulan_per_status AS
+         CREATE OR REPLACE VIEW vw_total_konseling_per_bulan_per_status AS
     SELECT
       DATE_TRUNC('month', k.tanggal_konseling)::date AS bulan,
       s.kode_status,
@@ -31,5 +31,5 @@ exports.up = (pgm) => {
  * @returns {Promise<void> | void}
  */
 exports.down = (pgm) => {
-     pgm.sql('DROP VIEW IF EXISTS view_total_konseling_per_bulan_per_status;');
+     pgm.sql('DROP VIEW IF EXISTS vw_total_konseling_per_bulan_per_status;');
 };

--- a/migrations/1748798647158_create-rata-rata-rating-view.js
+++ b/migrations/1748798647158_create-rata-rata-rating-view.js
@@ -10,7 +10,7 @@ exports.shorthands = undefined;
  */
 exports.up = (pgm) => {
     pgm.sql(`
-        CREATE OR REPLACE VIEW view_rata_rata_rating AS
+        CREATE OR REPLACE VIEW vw_rata_rata_rating AS
         SELECT
         AVG(rating)::numeric(4,2) AS rata_rata_rating,
         COUNT(*) AS jumlah_rating
@@ -24,5 +24,5 @@ exports.up = (pgm) => {
  * @returns {Promise<void> | void}
  */
 exports.down = (pgm) => {
-    pgm.sql('DROP VIEW IF EXISTS view_rata_rata_rating;');
+    pgm.sql('DROP VIEW IF EXISTS vw_rata_rata_rating;');
 };

--- a/migrations/1748817901517_create-konselor-stats-view.js
+++ b/migrations/1748817901517_create-konselor-stats-view.js
@@ -63,7 +63,7 @@ exports.up = (pgm) => {
 
   // Create the function to refresh the materialized view
   pgm.sql(`
-    CREATE OR REPLACE FUNCTION refresh_konselor_stats()
+    CREATE OR REPLACE FUNCTION fn_refresh_konselor_stats()
     RETURNS VOID AS $$ 
     BEGIN
       REFRESH MATERIALIZED VIEW CONCURRENTLY mv_konselor_stats;
@@ -78,7 +78,7 @@ exports.up = (pgm) => {
  * @returns {Promise<void> | void}
  */
 exports.down = (pgm) => {
-  pgm.sql('DROP FUNCTION IF EXISTS refresh_konselor_stats()');
+  pgm.sql('DROP FUNCTION IF EXISTS fn_refresh_konselor_stats()');
   pgm.sql('DROP MATERIALIZED VIEW IF EXISTS mv_konselor_stats');
   pgm.sql('DROP INDEX IF EXISTS mv_konselor_stats_unique_index');
 };

--- a/migrations/1748821333076_create-total-konselor-permintaan-janji-temu-view.js
+++ b/migrations/1748821333076_create-total-konselor-permintaan-janji-temu-view.js
@@ -10,7 +10,7 @@ exports.shorthands = undefined;
  */
 exports.up = (pgm) => {
   pgm.sql(`
-    CREATE OR REPLACE VIEW total_konselor_permintaan_janji_temu_view AS
+    CREATE OR REPLACE VIEW vw_total_permintaan_janji_temu_konselor AS
     SELECT
         kp.id AS konselor_id,
         kp.nama_lengkap AS konselor,
@@ -30,5 +30,5 @@ exports.up = (pgm) => {
  */
 exports.down = (pgm) => {
   // Drop view jika migrasi di-rollback
-  pgm.sql('DROP VIEW IF EXISTS total_konselor_permintaan_janji_temu_view');
+  pgm.sql('DROP VIEW IF EXISTS vw_total_permintaan_janji_temu_konselor');
 };

--- a/migrations/1748821655845_create-total-permintaan-janji-temu-per-prodi-view.js
+++ b/migrations/1748821655845_create-total-permintaan-janji-temu-per-prodi-view.js
@@ -10,7 +10,7 @@ exports.shorthands = undefined;
  */
 exports.up = (pgm) => {
     pgm.sql(`
-        CREATE OR REPLACE VIEW total_pengajuan_per_prodi_jenjang_view AS
+        CREATE OR REPLACE VIEW vw_total_pengajuan_per_prodi_jenjang AS
         SELECT 
             ps.jenjang,
             ps.nama_program_studi,
@@ -30,5 +30,5 @@ exports.up = (pgm) => {
  * @returns {Promise<void> | void}
  */
 exports.down = (pgm) => {
-    pgm.sql('DROP VIEW IF EXISTS total_pengajuan_per_prodi_jenjang_view');
+    pgm.sql('DROP VIEW IF EXISTS vw_total_pengajuan_per_prodi_jenjang');
 };

--- a/src/services/StatisticsService.js
+++ b/src/services/StatisticsService.js
@@ -238,7 +238,7 @@ class StatisticsService {
                         jenjang,
                         nama_program_studi,
                         total_pengajuan
-                    FROM total_pengajuan_per_prodi_jenjang_view
+                    FROM vw_total_pengajuan_per_prodi_jenjang
                     ORDER BY jenjang, total_pengajuan DESC;
                 `;
             const { rows } = await this._pool.query(query);
@@ -256,7 +256,7 @@ class StatisticsService {
                         jenjang,
                         nama_program_studi,
                         total_mahasiswa
-                    FROM view_demografi_mahasiswa_per_prodi
+                    FROM vw_demografi_mahasiswa_per_prodi
                     ORDER BY departemen, nama_program_studi;
                 `;
             const { rows } = await this._pool.query(query);
@@ -298,7 +298,7 @@ class StatisticsService {
                     status_label,
                     status_warna,
                     total
-                FROM view_total_konseling_per_bulan_per_status
+                FROM vw_total_konseling_per_bulan_per_status
                 ORDER BY bulan DESC, status_label;
             `;
             const { rows } = await this._pool.query(query);
@@ -310,7 +310,7 @@ class StatisticsService {
 
     async getAverageRating() {
         try {
-            const query = 'SELECT * FROM view_rata_rata_rating';
+            const query = 'SELECT * FROM vw_rata_rata_rating';
             const { rows } = await this._pool.query(query);
 
             return rows[0];


### PR DESCRIPTION
Aligns function, trigger, procedure, and view names with established conventions for better readability and maintainability.

- Functions now use `fn_` prefix (e.g., `fn_log_user_changes`).
- Triggers use `trg_` prefix (e.g., `trg_user_audit`).
- Views use `vw_` prefix (e.g., `vw_total_konseling`).
- Procedures use `prc_` prefix (e.g., `prc_tolak_verifikasi_mahasiswa_dan_janji_temu`).